### PR TITLE
add certutil install help for gentoo systems

### DIFF
--- a/truststore_linux.go
+++ b/truststore_linux.go
@@ -30,6 +30,8 @@ func init() {
 		CertutilInstallHelp = "yum install nss-tools"
 	case binaryExists("zypper"):
 		CertutilInstallHelp = "zypper install mozilla-nss-tools"
+	case binaryExists("emerge"):
+		CertutilInstallHelp = "echo 'dev-libs/nss utils' >> /etc/portage/package.use/nss && emerge -av dev-libs/nss"
 	}
 }
 


### PR DESCRIPTION
adds help to install certutil tool on gentoo systems: enable the `utils` use flag for `dev-libs/nss` then merge `dev-libs/nss`.