### PR TITLE
Dummy file to be able to build on FreeBSD

### DIFF
--- a/truststore_freebsd.go
+++ b/truststore_freebsd.go
@@ -1,0 +1,25 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cert
+
+import (
+	"os"
+)
+
+var (
+	FirefoxProfiles = []string{os.Getenv("HOME") + "/.mozilla/firefox/*",
+		os.Getenv("HOME") + "/.mozilla/firefox-trunk/*"}
+	NSSBrowsers = "Firefox and/or Chrome/Chromium"
+
+	CertutilInstallHelp string
+)
+
+func (ca *CA) installPlatform() error {
+	return nil
+}
+
+func (ca *CA) uninstallPlatform() error {
+	return nil
+}


### PR DESCRIPTION
Hi,

Without this dummy "truststore_freebsd.go" file, i get these errors if i try a build on FreeBSD 14.3 / Go 1.21.13:
```
./cert.go:143:16: ca.installPlatform undefined (type *CA has no field or method installPlatform)
./cert.go:156:105: undefined: NSSBrowsers
./cert.go:157:13: undefined: CertutilInstallHelp
./cert.go:158:89: undefined: NSSBrowsers
./cert.go:160:126: undefined: NSSBrowsers
./cert.go:161:81: undefined: CertutilInstallHelp
./cert.go:172:102: undefined: NSSBrowsers
./cert.go:174:13: undefined: CertutilInstallHelp
./cert.go:175:157: undefined: NSSBrowsers
./cert.go:176:89: undefined: CertutilInstallHelp
./cert.go:176:89: too many errors
```

After adding this file, the build is ok and i am able to build [symfony-cli](https://github.com/symfony-cli/symfony-cli). So i can install API Platform as described here : [Getting Started With API Platform with Symfony](https://api-platform.com/docs/symfony/#using-symfony-cli)

I guess this is really a workaround but, at least, i'm now able to use `symfony-cli` on FreeBSD :slightly_smiling_face:
